### PR TITLE
fix error message for out-of-range high value

### DIFF
--- a/timeperiod.py
+++ b/timeperiod.py
@@ -322,7 +322,7 @@ def _in_min_max(low, high, min, max, scale):
             raise InvalidFormat('An integer value is required for %s.' % scale)
 
         if high < min or high > max:
-            raise InvalidFormat('%d is not valid for %s. Valid options are between %d and %d.' % (low, scale, min, max))
+            raise InvalidFormat('%d is not valid for %s. Valid options are between %d and %d.' % (high, scale, min, max))
 
     return low, high
 


### PR DESCRIPTION
The input `hr {10-24}` currently gives the error message `10 is not valid for hour. Valid options are between 0 and 23.`
With this change, it should give the more useful error message `24 is not valid for hour. Valid options are between 0 and 23.`